### PR TITLE
fix: align header and nav on iPhone

### DIFF
--- a/packages/frontend/src/components/Header/HeaderBackground.tsx
+++ b/packages/frontend/src/components/Header/HeaderBackground.tsx
@@ -12,14 +12,14 @@ const Layout = styled.div({
   width: '100%',
 
   '&.is-home': {
-    height: '100vh',
+    height: 'calc(100lvh + 60px)',
   },
 
   [theme.breakpoint.md.mediaUp()]: {
     height: 300,
 
-    '&.currently-home': {
-      height: '100vh',
+    '&.is-home': {
+      height: 'calc(100lvh + 60px)',
     },
   },
 });

--- a/packages/frontend/src/components/Header/index.tsx
+++ b/packages/frontend/src/components/Header/index.tsx
@@ -20,14 +20,14 @@ const HeaderLayout = styled.header({
   },
 
   '&.is-home': {
-    height: '100vh',
+    height: 'calc(100lvh + 60px)',
   },
 
   [theme.breakpoint.md.mediaUp()]: {
     height: 300,
 
     '&.is-home': {
-      height: '100vh',
+      height: 'calc(100lvh + 60px)',
     },
   },
 });

--- a/packages/frontend/src/components/Nav/index.tsx
+++ b/packages/frontend/src/components/Nav/index.tsx
@@ -114,7 +114,13 @@ const Nav = () => {
   }, [layoutEl]);
 
   return (
-    <NavLayout ref={setLayoutEl}>
+    <NavLayout
+      ref={setLayoutEl}
+      style={{
+        paddingLeft: 0,
+        paddingRight: 0,
+      }}
+    >
       <NavLayout
         style={{
           color: 'rgb(255, 255, 255)',

--- a/packages/frontend/src/layouts/BaseLayout.astro
+++ b/packages/frontend/src/layouts/BaseLayout.astro
@@ -25,7 +25,7 @@ const headerKind = Astro.url.pathname === '/' ? 'home' : 'default';
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
     <title>{title}</title>
     <link
       rel="alternate"


### PR DESCRIPTION
This introduces a workaround for iOS 26 devices where the header cannot cover the entire page.